### PR TITLE
Add error-handling around Agoda host

### DIFF
--- a/src/services/listing/agodaListingProvider.js
+++ b/src/services/listing/agodaListingProvider.js
@@ -85,16 +85,16 @@ class AgodaListingProvider {
     const agodaListing = await AgodaListing.findOne({ where: { id } });
 
     if (!agodaListing) {
-      const error = new Error('No Agoda host found; is AGODA_HOST_EMAIL configured correctly?');
-      error.code = errors.NO_USER_FOUND;
+      const error = new Error('No such listing.');
+      error.code = errors.NOT_FOUND;
       throw error;
     }
 
     const host = await User.findOne({ where: { email: agodaHostEmail } });
 
     if (!host) {
-      const error = new Error('No such listing.');
-      error.code = errors.NOT_FOUND;
+      const error = new Error('No Agoda host found; is AGODA_HOST_EMAIL configured correctly?');
+      error.code = errors.NO_USER_FOUND;
       throw error;
     }
 


### PR DESCRIPTION
## Description
Ran into errors on production due to misconfiguration of environment; specifically, `AGODA_HOST_EMAIL` had no corresponding user in the database. The configuration of that environment has been fixed

## How to Test
1. `export AGODA_HOST_EMAIL="this is not even an email, there is no way this will work"`
2. `npm run dev`
3. From the client, search for listings in San Francisco
4. Expect to see search results (without Agoda listings; they're misconfigured!)
5. Try going to `/listings/agoda_2605`
6. Expect to see "No Agoda host" found error

(Note: The second link is unlikely to be hit by users in production, as Agoda search results wouldn't have shown up, but it exercises a call to the single-listing lookup from the Agoda listing provider to verify that handling occurs there. Error is unrecoverable in that context, so just trying to return something more informative here.)

## Further Work
None expected?

## Learnings
We had an `if (!host) return [];` but subsequent changes used that variable before that check was hit.

This is an example of why it makes sense to prefer [functions with a single exit point](http://wiki.c2.com/?SingleFunctionExitPoint): In this case, it's easy to miss that everything after that conditional exit is wrapped in an implicit `else` clause. Early `return` is still a [`GOTO`](http://www.cs.utexas.edu/users/EWD/ewd02xx/EWD215.PDF), just with fewer places to go.