### PR TITLE
Direct hosts to self-service to accept bookings

### DIFF
--- a/src/services/mail/templates/host/confirm.js
+++ b/src/services/mail/templates/host/confirm.js
@@ -41,8 +41,7 @@ module.exports = ({ guest, host, booking, listing }) => beemail({
     <br>
   `,
   conclusion: `
-    Please respond to this email within 24 hours to confirm this booking.
-    If we do not receive any response from you within 24 hours, we will cancel this booking.
+    Please visit ${settings.beenestHost}/host/bookings within 24 hours to accept this booking.
     <br>
     <br>
   `,


### PR DESCRIPTION
## Description
...to reduce operational requirements.

## How to Test
1. Make a booking as a guest (on a listing where you are the host)
2. Verify that email sends you to `/host/bookings` to accept that booking.

## Further Work
We have updated email copy for B2B, but it also reflects an expectation of instant booking. Should we implement some/all of that?