### PR TITLE
Add a hint about cookies.

### DIFF
--- a/src/controllers/graphql/schemas/booking/booking.js
+++ b/src/controllers/graphql/schemas/booking/booking.js
@@ -161,21 +161,21 @@ const resolvers = {
   Query: {
     allBookings: async (_, {}, { user }) => {
       if (!user || !user.isAdmin()) {
-        return new AuthenticationError('You are not authorized to view all bookings.');
+        return new AuthenticationError('You are not authorized to view all bookings. Are cookies enabled?');
       }
       const bookings = await BookingService.getAllBookings({limit: 100});
       return bookings.map(booking => booking.toJSON());
     },
     booking: async (_, { id }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to view this booking.');
+        return new AuthenticationError('You are not authorized to view this booking. Are cookies enabled?');
       }
       const booking = await BookingService.getById(id, user);
       return booking.toJSON();
     },
     guestBookings: async (_, { status }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to view these bookings.');
+        return new AuthenticationError('You are not authorized to view these bookings. Are cookies enabled?');
       }
       if (!status) {
         const bookings = await BookingService.getGuestBookings(user.id);
@@ -186,7 +186,7 @@ const resolvers = {
     },
     hostBookings: async (_, { input }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to view these bookings.');
+        return new AuthenticationError('You are not authorized to view these bookings. Are cookies enabled?');
       }
       const bookings = await BookingService.getHostBookings(user.id, input);
       return bookings.map(booking => booking.toJSON());
@@ -195,7 +195,7 @@ const resolvers = {
   Mutation: {
     approveBooking: async (_, { id }, { user }) => {
       if (!user || !(user.isAdmin() || await BookingService.isHostToBooking(user.id, id))) {
-        return new AuthenticationError('You are not authorized to approve this booking.');
+        return new AuthenticationError('You are not authorized to approve this booking. Are cookies enabled?');
       }
 
       const booking = await BookingService.approveBooking(id, user);
@@ -203,56 +203,56 @@ const resolvers = {
     },
     cancelBooking: async (_, { id }, { user }) => {
       if (!user || !(user.isAdmin() || await BookingService.isHostToBooking(user.id, id))) {
-        return new AuthenticationError('You are not authorized to cancel this booking.');
+        return new AuthenticationError('You are not authorized to cancel this booking. Are cookies enabled?');
       }
       const booking = await BookingService.cancelBooking(id, user);
       return booking.toJSON();
     },
     createBooking: async (_, { input }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to create this booking');
+        return new AuthenticationError('You are not authorized to create this booking. Are cookies enabled?');
       }
       const booking = await BookingService.createBookingWithQuotes(input, user);
       return booking.toJSON();
     },
     guestCancelBooking: async (_, { id }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to cancel this booking.');
+        return new AuthenticationError('You are not authorized to cancel this booking. Are cookies enabled?');
       }
       const booking = await BookingService.guestCancelBooking(id, user);
       return booking.toJSON();
     },
     guestConfirmBooking: async (_, { input }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to confirm this booking.');
+        return new AuthenticationError('You are not authorized to confirm this booking. Are cookies enabled?');
       }
       const booking = await BookingService.guestConfirmBooking(input, user);
       return booking.toJSON();
     },
     guestRejectPayment: async (_, { id }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to reject this payment.');
+        return new AuthenticationError('You are not authorized to reject this payment. Are cookies enabled?');
       }
       const booking = await BookingService.guestRejectPayment(id, user);
       return booking.toJSON();
     },
     guestSelectPayment: async (_, { input }, { user }) => {
       if (!user) {
-        return new AuthenticationError('You are not authorized to select this payment.');
+        return new AuthenticationError('You are not authorized to select this payment. Are cookies enabled?');
       }
       const booking = await BookingService.guestSelectPayment(input, user);
       return booking.toJSON();
     },
     rejectBooking: async (_, { id }, { user }) => {
       if (!user || !(user.isAdmin() || await BookingService.isHostToBooking(user.id, id))) {
-        return new AuthenticationError('You are not authorized to reject this booking.');
+        return new AuthenticationError('You are not authorized to reject this booking. Are cookies enabled?');
       }
       const booking = await BookingService.rejectBooking(id, user);
       return booking.toJSON();
     },
     payoutBooking: async (_, { id }, { user }) => {
       if (!user || !user.isAdmin()) {
-        return new AuthenticationError('You are not authorized to payout this booking.');
+        return new AuthenticationError('You are not authorized to payout this booking. Are cookies enabled?');
       }
       const booking = await BookingService.payoutBooking(id, user);
       return booking.toJSON();

--- a/src/controllers/graphql/schemas/conference/conference.js
+++ b/src/controllers/graphql/schemas/conference/conference.js
@@ -114,7 +114,7 @@ const resolvers = {
     },
     allConferences: async (_, {}, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('Unauthorized');
+        throw new ForbiddenError('Unauthorized. Are cookies enabled?');
       }
       const conferences = await ConferenceService.getAll();
       return conferences.map(conference => conference.toJSON());
@@ -127,7 +127,7 @@ const resolvers = {
   Mutation: {
     createConference: async (root, { input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('Unauthorized');
+        throw new ForbiddenError('Unauthorized. Are cookies enabled?');
       }
       await ConferenceService.create(input)
         .then(conference => {
@@ -144,14 +144,14 @@ const resolvers = {
     },
     updateConference: async (root, { id, input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('Unauthorized');
+        throw new ForbiddenError('Unauthorized. Are cookies enabled?');
       }
       const conference = await ConferenceService.update({ id, ...input });
       return conference.toJSON();
     },
     deleteConference: async (root, { id }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('Unauthorized');
+        throw new ForbiddenError('Unauthorized. Are cookies enabled?');
       }
       const result = await ConferenceService.delete(id);
       return {deleted: result > 0};

--- a/src/controllers/graphql/schemas/listing/listing.js
+++ b/src/controllers/graphql/schemas/listing/listing.js
@@ -281,7 +281,7 @@ const resolvers = {
   Query: {
     allListings: async (_, { input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new AuthenticationError('You are not authorized to see all listings.');
+        throw new AuthenticationError('You are not authorized to see all listings. Are cookies enabled?');
       }
       const { listings, count } = await ListingService.getAllListings(input);
       return {
@@ -291,7 +291,7 @@ const resolvers = {
     },
     hostListings: async (_, {}, { user }) => {
       if (!user) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       const listings = await ListingService.getHostListings(user.id);
       return listings.map(listing => listing.toJSON());
@@ -330,7 +330,7 @@ const resolvers = {
     activateListing: async (_, { id }, { user }) => {
       const listing = await ListingService.getListingById(id);
       if (!user || !user.canPublish(listing)) {
-        throw new AuthenticationError('You are not authorized to activate this listing.');
+        throw new AuthenticationError('You are not authorized to activate this listing. Are cookies enabled?');
       }
       return await ListingService.activateListing(id, user);
     },
@@ -344,14 +344,14 @@ const resolvers = {
     deactivateListing: async (_, { id }, { user }) => {
       const listing = await ListingService.getListingById(id);
       if (!user || !user.canPublish(listing)) {
-        throw new AuthenticationError('You are not authorized to deactivate this listing.');
+        throw new AuthenticationError('You are not authorized to deactivate this listing. Are cookies enabled?');
       }
       return await ListingService.deactivateListing(id);
     },
     deleteListing: async (_, { id }, { user }) => {
       const listing = await ListingService.getListingById(id);
       if (!user || !user.canEdit(listing)) {
-        throw new AuthenticationError('You are not authorized to delete this listing.');
+        throw new AuthenticationError('You are not authorized to delete this listing. Are cookies enabled?');
       }
       const deletedListing = await ListingService.deleteListing(id);
       return deletedListing.toJSON({ requestor: user });
@@ -359,7 +359,7 @@ const resolvers = {
     duplicateListing: async (_, { id }, { user }) => {
       const listing = await ListingService.getListingById(id);
       if (!user || !user.canEdit(listing)) {
-        throw new AuthenticationError('You are not authorized to duplicate this listing.');
+        throw new AuthenticationError('You are not authorized to duplicate this listing. Are cookies enabled?');
       }
       const duplicatedListing = await ListingService.duplicateListing(id, user);
       return duplicatedListing.toJSON({ requestor: user });
@@ -367,7 +367,7 @@ const resolvers = {
     updateListing: async (_, { id, input }, { user }) => {
       const listing = await ListingService.getListingById(id);
       if (!user || !user.canEdit(listing)) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       const updatedListing = await ListingService.updateListing(
         { id, ...input },

--- a/src/controllers/graphql/schemas/user/user.js
+++ b/src/controllers/graphql/schemas/user/user.js
@@ -154,28 +154,28 @@ const resolvers = {
   Query: {
     user: async (_, {}, { user }) => {
       if (!user) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       const foundUser = await UserService.getById(user.id);
       return foundUser.toJSON({requestor: user});
     },
     allUsers: async (_, {}, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       const users = await UserService.getAllUsers();
       return users.map(user => user.toJSON({ requestor: user }));
     },
     getUserById: async (_, { id }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       const foundUser = await UserService.getById(id);
       return foundUser.toJSON({requestor: user});
     },
     searchHosts: async (_, { input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       const { users, count } = await UserService.search({ ...input, isHost: true });
       return {
@@ -185,7 +185,7 @@ const resolvers = {
     },
     searchUsers: async (_, { input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       const { users, count } = await UserService.search({ ...input });
       return {
@@ -197,13 +197,13 @@ const resolvers = {
   Mutation: {
     adminCreateHost: async (_, { input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       return await UserService.adminCreateHost(input);
     },
     createOrLoginWithProviders: async (_, { id }, { user }) => {
       if (user) {
-        const error = new AuthenticationError('You are already logged in.');
+        const error = new AuthenticationError('You are already logged in. Are cookies enabled?');
         error.code = errors.ALREADY_LOGGED_IN;
         throw error;
       }
@@ -211,7 +211,7 @@ const resolvers = {
     },
     createUser: async (_, { input }, { user }) => {
       if (user) {
-        const error = new AuthenticationError('You are already logged in.');
+        const error = new AuthenticationError('You are already logged in. Are cookies enabled?');
         error.code = errors.ALREADY_LOGGED_IN;
         throw error;
       }
@@ -219,7 +219,7 @@ const resolvers = {
     },
     createHost: async (_, { input }, { user }) => {
       if (user) {
-        const error = new AuthenticationError('You are already logged in.');
+        const error = new AuthenticationError('You are already logged in. Are cookies enabled?');
         error.code = errors.ALREADY_LOGGED_IN;
         throw error;
       }
@@ -227,33 +227,33 @@ const resolvers = {
     },
     deleteUser: async (_, { id }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       const deletedUser = await UserService.deleteUser(id);
       return deletedUser.toJSON({ requestor: user });
     },
     createStripeLoginLink: async (_, { }, { user }) => {
       if (!user) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       return await stripe.createStripeLoginLink(user);
     },
     refreshVerificationStatus: async (_, { }, { user }) => {
       if (!user) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       const updatedUserVerificationStatus = await UserService.refreshVerificationStatus(user.id);
       return updatedUserVerificationStatus.toJSON();
     },
     updateHost: async (_, { input }, { user }) => {
       if (!user || !user.isAdmin()) {
-        throw new ForbiddenError('You are not authorized.');
+        throw new ForbiddenError('You are not authorized. Are cookies enabled?');
       }
       return await UserService.updateHost(input, user);
     },
     updateWalletAddress: async (_, { input }, { user }) => {
       if (!user) {
-        const error = new AuthenticationError('You are not logged in.');
+        const error = new AuthenticationError('You are not logged in. Are cookies enabled?');
         error.code = errors.NOT_LOGGED_IN;
         throw error;
       }
@@ -263,14 +263,14 @@ const resolvers = {
     },
     updateUser: async(_, { input }, { user }) => {
       if (!user) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       const updatedUser = await UserService.updateUser(input, user);
       return updatedUser.toJSON({ requestor: user });
     },
     contactUser: async(_, { input }, { user }) => {
       if (!user) {
-        throw new AuthenticationError('You are not logged in.');
+        throw new AuthenticationError('You are not logged in. Are cookies enabled?');
       }
       const { bookingId, listingId, message, recipientId, subject } = input;
       const recipient = await UserService.getById(recipientId);


### PR DESCRIPTION
## Description
After thebeetoken/beenest-web#348 disabling cookies prevents booking with a generic "you are not authorized" error. (Before that the app just crashed.)

This adds a hint ("Are cookies enabled?") to authorization errors, as cookies are a non-obvious reason for auth failure.

## How to Test
1. Disable cookies
2. Try to make a booking
3. Expect the error message to prompt you about cookies

## Further Work
Don't think there is a recovery strategy here, so no further work expected.

## Learnings
Lots of repetition in this PR. Part of me was like *um DRY* but the rest of me was like ***um YOLO***
